### PR TITLE
Stop piping output from demeteorizer to /dev/null

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -26,9 +26,8 @@ ARCH=os.linux.x86_64
 # TODO Test for demeteorizer flags
 # --json || --debug
 
-echo "Demeteorizing application for $(meteor --version)"
 cd $INPUT_DIR
-demeteorizer --output $OUTPUT_DIR --architecture $ARCH > /dev/null 2>&1
+demeteorizer --output $OUTPUT_DIR --architecture $ARCH
 
 # Searches a directory top-down looking for a file.
 findFile() {

--- a/bin/build
+++ b/bin/build
@@ -20,14 +20,11 @@ NVM_DIR=$HOME/.nvm
 source /opt/nvm/nvm.sh
 
 # Demeteorizer flags
-ARCH=os.linux.x86_64
-
-# Turn Meteor app into a Node.js app
 # TODO Test for demeteorizer flags
 # --json || --debug
 
 cd $INPUT_DIR
-demeteorizer --output $OUTPUT_DIR --architecture $ARCH
+demeteorizer --output $OUTPUT_DIR
 
 # Searches a directory top-down looking for a file.
 findFile() {


### PR DESCRIPTION
- Stop piping output from demeteorizer to /dev/null

Piping output to /dev/null is not beneficial in any way. It is also better to display the success/failure messages of demeteorizer.

Closes #4 
